### PR TITLE
Problème des cases doubles améliorées

### DIFF
--- a/1958135962/Data/BBS Maps/Utility/BBS_Balance.lua
+++ b/1958135962/Data/BBS Maps/Utility/BBS_Balance.lua
@@ -3357,6 +3357,7 @@ function Terraforming_Best(plot, missing_amount, best_1ring, best_2ring, avg_rin
 							target_tiles[j].index = adjacentPlot:GetIndex()
 							valid_count = valid_count + 1
 							__Debug("Terraforming Best: Not Enough Valid Plots - Add Plot X",adjacentPlot:GetX(),"Y:",adjacentPlot:GetY());
+                     break;
 						end
 					end				
 				end

--- a/1958135962/Data/BBS Maps/Utility/BBS_Balance.lua
+++ b/1958135962/Data/BBS Maps/Utility/BBS_Balance.lua
@@ -513,11 +513,7 @@ function BBS_Script()
 						
 						if ( (majList[i].desert_outer + majList[i].desert_inner + majList[i].desert_start) > 6 and IsDesertCiv(majList[i].civ) == false ) then
 							__Debug("Terraforming Desert Start X: ", majList[i].plotX, "Start Y: ", majList[i].plotY, "Player: ",i," ",majList[i].leader, majList[i].civ);
-                     if( IsTundraCiv(majList[i].civ) == true ) then 
-                        Terraforming(Map.GetPlot(majList[i].plotX,majList[i].plotY), iBalancingThree,1);
-                     else
-                        Terraforming(Map.GetPlot(majList[i].plotX,majList[i].plotY), iBalancingThree,0);
-                     end
+							Terraforming(Map.GetPlot(majList[i].plotX,majList[i].plotY), iBalancingThree,0);
 						end
 						
 

--- a/1958135962/Data/BBS Maps/Utility/BBS_Balance.lua
+++ b/1958135962/Data/BBS Maps/Utility/BBS_Balance.lua
@@ -513,7 +513,11 @@ function BBS_Script()
 						
 						if ( (majList[i].desert_outer + majList[i].desert_inner + majList[i].desert_start) > 6 and IsDesertCiv(majList[i].civ) == false ) then
 							__Debug("Terraforming Desert Start X: ", majList[i].plotX, "Start Y: ", majList[i].plotY, "Player: ",i," ",majList[i].leader, majList[i].civ);
-							Terraforming(Map.GetPlot(majList[i].plotX,majList[i].plotY), iBalancingThree,0);
+                     if( IsTundraCiv(majList[i].civ) == true ) then 
+                        Terraforming(Map.GetPlot(majList[i].plotX,majList[i].plotY), iBalancingThree,1);
+                     else
+                        Terraforming(Map.GetPlot(majList[i].plotX,majList[i].plotY), iBalancingThree,0);
+                     end
 						end
 						
 


### PR DESCRIPTION
Quand trop peu de cases sont disponibles pour l'upgrade, une recherche est faite pour en ajouter.
Dans certains cas, les cases sont ajoutés plusieurs fois à la liste et donc "améliorées" plusieurs fois.

L'ajout du "break" garanti qu'on ne peut pas ajouter plusieurs fois la même case.

Testé avec le spawn d'uhlas et ça fonctionne :)